### PR TITLE
feat(imposter): add word data for all 12 categories

### DIFF
--- a/src/data/imposter/animals.json
+++ b/src/data/imposter/animals.json
@@ -1,0 +1,21 @@
+{
+  "category": "Animals",
+  "emoji": "🐾",
+  "words": {
+    "easy": [
+      "dog", "cat", "horse", "chicken", "fish",
+      "rabbit", "elephant", "lion", "monkey", "bear",
+      "snake", "eagle", "dolphin"
+    ],
+    "medium": [
+      "platypus", "chameleon", "flamingo", "porcupine", "jaguar",
+      "pelican", "walrus", "iguana", "meerkat", "armadillo",
+      "bison", "raccoon", "seahorse"
+    ],
+    "hard": [
+      "axolotl", "pangolin", "quokka", "narwhal", "okapi",
+      "capybara", "tapir", "dugong", "binturong", "kinkajou",
+      "serval", "fossa", "gharial"
+    ]
+  }
+}

--- a/src/data/imposter/countries-cities.json
+++ b/src/data/imposter/countries-cities.json
@@ -1,0 +1,21 @@
+{
+  "category": "Countries & Cities",
+  "emoji": "🌍",
+  "words": {
+    "easy": [
+      "Paris", "New York", "London", "Japan", "Australia",
+      "Brazil", "Canada", "Italy", "Egypt", "India",
+      "Mexico", "China", "Germany"
+    ],
+    "medium": [
+      "Prague", "Morocco", "Buenos Aires", "Vietnam", "Istanbul",
+      "Singapore", "Cuba", "Dublin", "Budapest", "Peru",
+      "Bangkok", "Lisbon", "Kenya"
+    ],
+    "hard": [
+      "Reykjavik", "Bhutan", "Liechtenstein", "Montevideo", "Ljubljana",
+      "Suriname", "Tbilisi", "Valletta", "Tuvalu", "Bratislava",
+      "Ouagadougou", "Bishkek", "Andorra"
+    ]
+  }
+}

--- a/src/data/imposter/fashion-clothing.json
+++ b/src/data/imposter/fashion-clothing.json
@@ -1,0 +1,21 @@
+{
+  "category": "Fashion & Clothing",
+  "emoji": "👗",
+  "words": {
+    "easy": [
+      "jeans", "sneakers", "hat", "dress", "sunglasses",
+      "jacket", "scarf", "boots", "T-shirt", "hoodie",
+      "shorts", "sandals", "socks"
+    ],
+    "medium": [
+      "cardigan", "blazer", "turtleneck", "dungarees", "stilettos",
+      "corset", "parka", "poncho", "beret", "cufflinks",
+      "kimono", "loafers", "leggings"
+    ],
+    "hard": [
+      "fascinator", "jodhpurs", "espadrilles", "cheongsam", "dirndl",
+      "dashiki", "sari", "kaftan", "lederhosen", "mantilla",
+      "sherwani", "dhoti", "balmoral"
+    ]
+  }
+}

--- a/src/data/imposter/food-drinks.json
+++ b/src/data/imposter/food-drinks.json
@@ -1,0 +1,21 @@
+{
+  "category": "Food & Drinks",
+  "emoji": "🍕",
+  "words": {
+    "easy": [
+      "pizza", "burger", "pasta", "rice", "chocolate",
+      "coffee", "ice cream", "bread", "salad", "soup",
+      "orange juice", "sandwich", "pancake"
+    ],
+    "medium": [
+      "sushi", "hummus", "croissant", "tiramisu", "kombucha",
+      "paella", "ramen", "falafel", "guacamole", "dim sum",
+      "gnocchi", "churros", "pho"
+    ],
+    "hard": [
+      "borscht", "ceviche", "gochujang", "shakshuka", "tempeh",
+      "haggis", "kimchi jjigae", "bibimbap", "rendang", "pierogi",
+      "injera", "miso", "tzatziki"
+    ]
+  }
+}

--- a/src/data/imposter/hobbies-activities.json
+++ b/src/data/imposter/hobbies-activities.json
@@ -1,0 +1,21 @@
+{
+  "category": "Hobbies & Activities",
+  "emoji": "🎨",
+  "words": {
+    "easy": [
+      "painting", "cooking", "reading", "dancing", "gardening",
+      "fishing", "camping", "singing", "hiking", "photography",
+      "yoga", "skateboarding", "bowling"
+    ],
+    "medium": [
+      "pottery", "origami", "scuba diving", "rock climbing", "calligraphy",
+      "birdwatching", "woodworking", "geocaching", "beekeeping", "juggling",
+      "parkour", "quilting", "whittling"
+    ],
+    "hard": [
+      "falconry", "topiary", "spelunking", "taxidermy", "orienteering",
+      "pyrography", "bookbinding", "fermenting", "mudlarking", "panning",
+      "canyoneering", "kintsugi", "tufting"
+    ]
+  }
+}

--- a/src/data/imposter/household-items.json
+++ b/src/data/imposter/household-items.json
@@ -1,0 +1,21 @@
+{
+  "category": "Household Items",
+  "emoji": "🏠",
+  "words": {
+    "easy": [
+      "chair", "table", "lamp", "mirror", "pillow",
+      "spoon", "towel", "clock", "blanket", "plate",
+      "cup", "broom", "soap"
+    ],
+    "medium": [
+      "colander", "whisk", "coaster", "corkscrew", "ladle",
+      "dustpan", "plunger", "thermostat", "curtain rod", "garlic press",
+      "ice tray", "doorstop", "trivet"
+    ],
+    "hard": [
+      "pestle", "zester", "awl", "antimacassar", "finial",
+      "escutcheon", "ferrule", "aglet", "wainscoting", "credenza",
+      "chafing dish", "bolster", "settee"
+    ]
+  }
+}

--- a/src/data/imposter/index.ts
+++ b/src/data/imposter/index.ts
@@ -1,0 +1,45 @@
+import animals from "./animals.json";
+import foodDrinks from "./food-drinks.json";
+import moviesTv from "./movies-tv.json";
+import sports from "./sports.json";
+import countriesCities from "./countries-cities.json";
+import occupations from "./occupations.json";
+import householdItems from "./household-items.json";
+import music from "./music.json";
+import nature from "./nature.json";
+import technology from "./technology.json";
+import fashionClothing from "./fashion-clothing.json";
+import hobbiesActivities from "./hobbies-activities.json";
+import type { CategoryData } from "@/lib/gameEngine";
+
+export type { CategoryData };
+
+export const categories: CategoryData[] = [
+  animals,
+  foodDrinks,
+  moviesTv,
+  sports,
+  countriesCities,
+  occupations,
+  householdItems,
+  music,
+  nature,
+  technology,
+  fashionClothing,
+  hobbiesActivities,
+];
+
+export {
+  animals,
+  foodDrinks,
+  moviesTv,
+  sports,
+  countriesCities,
+  occupations,
+  householdItems,
+  music,
+  nature,
+  technology,
+  fashionClothing,
+  hobbiesActivities,
+};

--- a/src/data/imposter/movies-tv.json
+++ b/src/data/imposter/movies-tv.json
@@ -1,0 +1,21 @@
+{
+  "category": "Movies & TV",
+  "emoji": "🎬",
+  "words": {
+    "easy": [
+      "Titanic", "Harry Potter", "The Lion King", "Spider-Man", "Star Wars",
+      "Friends", "Batman", "Frozen", "Shrek", "The Simpsons",
+      "Finding Nemo", "Toy Story", "Stranger Things"
+    ],
+    "medium": [
+      "Inception", "The Godfather", "Breaking Bad", "Jurassic Park", "Gladiator",
+      "The Matrix", "Pulp Fiction", "Game of Thrones", "Fight Club", "Interstellar",
+      "The Shawshank Redemption", "Forrest Gump", "Black Mirror"
+    ],
+    "hard": [
+      "Memento", "Eternal Sunshine", "Mulholland Drive", "Oldboy", "Amelie",
+      "Spirited Away", "Parasite", "The Grand Budapest Hotel", "Blade Runner", "A Clockwork Orange",
+      "Twin Peaks", "Pan's Labyrinth", "Donnie Darko"
+    ]
+  }
+}

--- a/src/data/imposter/music.json
+++ b/src/data/imposter/music.json
@@ -1,0 +1,21 @@
+{
+  "category": "Music",
+  "emoji": "🎵",
+  "words": {
+    "easy": [
+      "guitar", "piano", "drums", "hip hop", "rock",
+      "violin", "microphone", "karaoke", "concert", "jazz",
+      "pop music", "DJ", "flute"
+    ],
+    "medium": [
+      "synthesizer", "acoustic", "reggae", "orchestra", "tempo",
+      "bass guitar", "harmonica", "blues", "gospel", "ukulele",
+      "metronome", "vinyl record", "saxophone"
+    ],
+    "hard": [
+      "theremin", "sitar", "didgeridoo", "gamelan", "hurdy-gurdy",
+      "zither", "balalaika", "mbira", "oud", "shamisen",
+      "erhu", "tabla", "bandoneón"
+    ]
+  }
+}

--- a/src/data/imposter/nature.json
+++ b/src/data/imposter/nature.json
@@ -1,0 +1,21 @@
+{
+  "category": "Nature",
+  "emoji": "🌿",
+  "words": {
+    "easy": [
+      "mountain", "ocean", "river", "rainbow", "volcano",
+      "desert", "forest", "waterfall", "beach", "thunder",
+      "snow", "sunset", "island"
+    ],
+    "medium": [
+      "glacier", "geyser", "stalactite", "tundra", "mangrove",
+      "coral reef", "aurora", "monsoon", "canyon", "plateau",
+      "lagoon", "fjord", "delta"
+    ],
+    "hard": [
+      "fumarole", "scree", "moraine", "cenote", "sargasso",
+      "esker", "drumlin", "cirque", "breccia", "karst",
+      "travertine", "tufa", "caldera"
+    ]
+  }
+}

--- a/src/data/imposter/occupations.json
+++ b/src/data/imposter/occupations.json
@@ -1,0 +1,21 @@
+{
+  "category": "Occupations",
+  "emoji": "💼",
+  "words": {
+    "easy": [
+      "doctor", "teacher", "police officer", "firefighter", "chef",
+      "pilot", "nurse", "dentist", "farmer", "mechanic",
+      "lawyer", "actor", "singer"
+    ],
+    "medium": [
+      "architect", "accountant", "paramedic", "translator", "veterinarian",
+      "geologist", "pharmacist", "journalist", "therapist", "electrician",
+      "marine biologist", "archaeologist", "stockbroker"
+    ],
+    "hard": [
+      "actuary", "sommelier", "epidemiologist", "cartographer", "entomologist",
+      "etymologist", "lapidary", "audiologist", "toxicologist", "arborist",
+      "oenologist", "farrier", "dramaturge"
+    ]
+  }
+}

--- a/src/data/imposter/sports.json
+++ b/src/data/imposter/sports.json
@@ -1,0 +1,21 @@
+{
+  "category": "Sports",
+  "emoji": "⚽",
+  "words": {
+    "easy": [
+      "soccer", "basketball", "tennis", "swimming", "baseball",
+      "volleyball", "golf", "boxing", "hockey", "rugby",
+      "cricket", "cycling", "running"
+    ],
+    "medium": [
+      "fencing", "archery", "badminton", "water polo", "rowing",
+      "handball", "lacrosse", "squash", "bobsled", "javelin",
+      "triathlon", "kayaking", "pole vault"
+    ],
+    "hard": [
+      "curling", "sepak takraw", "pelota", "kabaddi", "buzkashi",
+      "jai alai", "bossaball", "hurling", "korfball", "bandy",
+      "capoeira", "netball", "petanque"
+    ]
+  }
+}

--- a/src/data/imposter/technology.json
+++ b/src/data/imposter/technology.json
@@ -1,0 +1,21 @@
+{
+  "category": "Technology",
+  "emoji": "💻",
+  "words": {
+    "easy": [
+      "smartphone", "laptop", "WiFi", "headphones", "camera",
+      "television", "video game", "tablet", "USB", "Bluetooth",
+      "emoji", "selfie", "GPS"
+    ],
+    "medium": [
+      "algorithm", "cryptocurrency", "virtual reality", "drone", "podcast",
+      "cloud storage", "firewall", "ethernet", "motherboard", "server",
+      "machine learning", "augmented reality", "SSD"
+    ],
+    "hard": [
+      "FPGA", "quantum computing", "neural network", "blockchain node", "LIDAR",
+      "mesh network", "edge computing", "homomorphic encryption", "digital twin", "memristor",
+      "photonic chip", "RISC-V", "neuromorphic"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add 468 words across 12 categories for The Imposter game, split evenly into easy/medium/hard tiers (13 words each, 39 per category)
- Categories: Animals, Food & Drinks, Movies & TV, Sports, Countries & Cities, Occupations, Household Items, Music, Nature, Technology, Fashion & Clothing, Hobbies & Activities
- Typed `index.ts` exports all categories matching the existing `CategoryData` interface

## Test plan
- [x] `npm run build` passes — TypeScript types verified
- [x] No duplicate words across categories
- [x] All words are party-game appropriate

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)