### PR TITLE
feat(imposter): build discussion phase with timer

### DIFF
--- a/.doc-check-passed
+++ b/.doc-check-passed
@@ -1,1 +1,0 @@
-src/app/imposter/play/page.tsx

--- a/src/app/imposter/play/page.tsx
+++ b/src/app/imposter/play/page.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { AnimatePresence, motion } from "framer-motion";
 import { GameShell } from "@/components/layout/GameShell";
 import { PassScreen } from "@/components/game/PassScreen";
 import { PrivacyReveal } from "@/components/game/PrivacyReveal";
+import { CountdownTimer } from "@/components/game/CountdownTimer";
+import { Button } from "@/components/ui/Button";
+import { Modal } from "@/components/ui/Modal";
 import { useGameStore } from "@/lib/store";
+import { useWakeLock } from "@/hooks/useWakeLock";
+import { vibratePattern } from "@/lib/haptics";
 
 const ACCENT = "#8B5CF6";
 
@@ -62,12 +67,24 @@ export default function ImposterPlay() {
     );
   }
 
-  // Discussion, voting, results phases — placeholder for future issues
+  // Discussion phase
+  if (phase === "discussion") {
+    return (
+      <DiscussionPhase
+        category={category}
+        timerDuration={imposterState.timerDuration}
+        playerCount={players.length}
+        imposterCount={imposterState.imposterCount}
+        onEnd={() => updateImposterState({ phase: "voting" })}
+      />
+    );
+  }
+
+  // Voting, results phases — placeholder for future issues
   return (
     <GameShell title="The Imposter" accentColor={ACCENT}>
       <div className="text-center py-12">
         <p className="text-text-secondary text-lg">
-          {phase === "discussion" && "Discussion phase coming next..."}
           {phase === "voting" && "Voting phase coming next..."}
           {phase === "results" && "Results phase coming next..."}
         </p>
@@ -179,5 +196,139 @@ function AssigningPhase({
 function useSubPhase() {
   const [subPhase, setSubPhase] = useState<PlayPhase>("pass");
   return { subPhase, setSubPhase };
+}
+
+function DiscussionPhase({
+  category,
+  timerDuration,
+  playerCount,
+  imposterCount,
+  onEnd,
+}: {
+  category: string;
+  timerDuration: number | null;
+  playerCount: number;
+  imposterCount: number;
+  onEnd: () => void;
+}) {
+  useWakeLock(true);
+  const [showEndModal, setShowEndModal] = useState(false);
+  const [elapsed, setElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval>>(null);
+
+  // Elapsed timer for "no limit" mode
+  useEffect(() => {
+    if (timerDuration !== null) return;
+    intervalRef.current = setInterval(() => {
+      setElapsed((prev) => prev + 1);
+    }, 1000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [timerDuration]);
+
+  const handleTimerComplete = useCallback(() => {
+    vibratePattern();
+    onEnd();
+  }, [onEnd]);
+
+  const handleEndEarly = () => {
+    setShowEndModal(false);
+    onEnd();
+  };
+
+  const formatTime = (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  };
+
+  return (
+    <GameShell title="The Imposter" accentColor={ACCENT}>
+      <div className="flex flex-col items-center text-center gap-6 pt-4">
+        {/* Category */}
+        <div>
+          <p className="text-text-muted text-sm mb-1">Category</p>
+          <h2 className="text-2xl font-bold" style={{ color: ACCENT }}>
+            {category}
+          </h2>
+        </div>
+
+        {/* Timer */}
+        <div className="py-4">
+          {timerDuration !== null ? (
+            <CountdownTimer
+              duration={timerDuration}
+              onComplete={handleTimerComplete}
+              autoStart
+              size={220}
+            />
+          ) : (
+            <div className="flex flex-col items-center">
+              <p className="text-text-muted text-sm mb-2">Time elapsed</p>
+              <span className="text-5xl font-bold text-text-primary">
+                {formatTime(elapsed)}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Rules reminder */}
+        <div className="bg-surface border border-border rounded-[var(--radius-card)] p-4 w-full max-w-sm">
+          <p className="text-text-secondary text-sm leading-relaxed">
+            Describe things related to the word. The imposter doesn&apos;t know
+            the word — find them!
+          </p>
+        </div>
+
+        {/* Game info */}
+        <p className="text-text-muted text-sm">
+          {playerCount} players · {imposterCount}{" "}
+          {imposterCount === 1 ? "imposter" : "imposters"}
+        </p>
+
+        {/* End discussion button */}
+        <Button
+          variant="secondary"
+          size="md"
+          fullWidth
+          onClick={() => setShowEndModal(true)}
+          className="max-w-sm"
+        >
+          End Discussion
+        </Button>
+      </div>
+
+      {/* Confirmation modal */}
+      <Modal open={showEndModal} onClose={() => setShowEndModal(false)}>
+        <div className="text-center space-y-4">
+          <h3 className="text-xl font-bold text-text-primary">
+            End discussion?
+          </h3>
+          <p className="text-text-secondary">
+            Move on to voting now?
+          </p>
+          <div className="flex gap-3">
+            <Button
+              variant="secondary"
+              size="md"
+              fullWidth
+              onClick={() => setShowEndModal(false)}
+            >
+              Keep talking
+            </Button>
+            <Button
+              accentColor={ACCENT}
+              size="md"
+              fullWidth
+              onClick={handleEndEarly}
+            >
+              Vote now
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </GameShell>
+  );
 }
 


### PR DESCRIPTION
## Summary
- Add discussion phase with circular countdown timer (color-coded urgency)
- "No limit" mode shows elapsed time instead of countdown
- Rules reminder, player/imposter count, wake lock, haptic alerts
- "End Discussion" button with confirmation modal transitions to voting

## Test plan
- [x] `npm run build` passes
- [x] Timer counts down correctly and triggers voting phase on complete
- [x] "No limit" mode shows elapsed time
- [x] End discussion modal works with both cancel and confirm
- [ ] Visual QA on mobile

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)