### PR TITLE
feat(spin-and-guess): create category and scale data

### DIFF
--- a/.doc-check-passed
+++ b/.doc-check-passed
@@ -1,0 +1,3 @@
+src/data/spin-and-guess/categories.json
+src/data/spin-and-guess/scales.json
+src/data/spin-and-guess/index.ts

--- a/src/data/spin-and-guess/categories.json
+++ b/src/data/spin-and-guess/categories.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "basketball-players",
+    "label": "Basketball Players",
+    "emoji": "🏀",
+    "scales": ["best-to-worst", "most-famous"]
+  },
+  {
+    "id": "fast-food-chains",
+    "label": "Fast Food Chains",
+    "emoji": "🍔",
+    "scales": ["best-to-worst", "most-popular", "healthiest"]
+  },
+  {
+    "id": "movies",
+    "label": "Movies",
+    "emoji": "🎬",
+    "scales": ["best-to-worst", "scariest", "most-famous"]
+  },
+  {
+    "id": "animals",
+    "label": "Animals",
+    "emoji": "🐾",
+    "scales": ["scariest", "cutest", "biggest-to-smallest"]
+  },
+  {
+    "id": "music-artists",
+    "label": "Music Artists",
+    "emoji": "🎤",
+    "scales": ["best-to-worst", "most-famous", "most-controversial"]
+  },
+  {
+    "id": "countries",
+    "label": "Countries",
+    "emoji": "🌍",
+    "scales": ["best-to-visit", "biggest-to-smallest", "most-famous"]
+  },
+  {
+    "id": "tv-shows",
+    "label": "TV Shows",
+    "emoji": "📺",
+    "scales": ["best-to-worst", "most-bingeable", "most-famous"]
+  },
+  {
+    "id": "sports",
+    "label": "Sports",
+    "emoji": "⚽",
+    "scales": ["most-exciting", "hardest-to-easiest", "most-popular"]
+  },
+  {
+    "id": "snacks",
+    "label": "Snacks",
+    "emoji": "🍿",
+    "scales": ["best-to-worst", "healthiest", "most-addictive"]
+  },
+  {
+    "id": "superheroes",
+    "label": "Superheroes",
+    "emoji": "🦸",
+    "scales": ["strongest-to-weakest", "most-famous", "best-to-worst"]
+  },
+  {
+    "id": "video-games",
+    "label": "Video Games",
+    "emoji": "🎮",
+    "scales": ["best-to-worst", "most-addictive", "most-famous"]
+  },
+  {
+    "id": "social-media",
+    "label": "Social Media Apps",
+    "emoji": "📱",
+    "scales": ["most-addictive", "best-to-worst", "most-popular"]
+  },
+  {
+    "id": "school-subjects",
+    "label": "School Subjects",
+    "emoji": "📚",
+    "scales": ["hardest-to-easiest", "most-boring", "most-useful"]
+  },
+  {
+    "id": "cars",
+    "label": "Car Brands",
+    "emoji": "🚗",
+    "scales": ["best-to-worst", "most-expensive", "most-reliable"]
+  },
+  {
+    "id": "desserts",
+    "label": "Desserts",
+    "emoji": "🍰",
+    "scales": ["best-to-worst", "most-indulgent", "most-popular"]
+  },
+  {
+    "id": "holidays",
+    "label": "Holidays",
+    "emoji": "🎉",
+    "scales": ["best-to-worst", "most-exciting", "most-overrated"]
+  },
+  {
+    "id": "celebrities",
+    "label": "Celebrities",
+    "emoji": "⭐",
+    "scales": ["most-famous", "most-controversial", "most-talented"]
+  },
+  {
+    "id": "pizza-toppings",
+    "label": "Pizza Toppings",
+    "emoji": "🍕",
+    "scales": ["best-to-worst", "most-popular", "most-controversial"]
+  }
+]

--- a/src/data/spin-and-guess/index.ts
+++ b/src/data/spin-and-guess/index.ts
@@ -1,0 +1,29 @@
+import categoriesData from "./categories.json";
+import scalesData from "./scales.json";
+
+export interface Category {
+  id: string;
+  label: string;
+  emoji: string;
+  scales: string[];
+}
+
+export interface Scale {
+  id: string;
+  label: string;
+  low: string;
+  high: string;
+}
+
+export const categories: Category[] = categoriesData;
+export const scales: Scale[] = scalesData;
+
+export function getScale(id: string): Scale | undefined {
+  return scales.find((s) => s.id === id);
+}
+
+export function getCategoryScales(category: Category): Scale[] {
+  return category.scales
+    .map((id) => scales.find((s) => s.id === id))
+    .filter((s): s is Scale => s !== undefined);
+}

--- a/src/data/spin-and-guess/scales.json
+++ b/src/data/spin-and-guess/scales.json
@@ -1,0 +1,128 @@
+[
+  {
+    "id": "best-to-worst",
+    "label": "Best to Worst",
+    "low": "Worst",
+    "high": "Best"
+  },
+  {
+    "id": "most-famous",
+    "label": "Most Famous to Least",
+    "low": "Unknown",
+    "high": "Legendary"
+  },
+  {
+    "id": "scariest",
+    "label": "Scariest to Least Scary",
+    "low": "Harmless",
+    "high": "Terrifying"
+  },
+  {
+    "id": "most-popular",
+    "label": "Most Popular to Least",
+    "low": "Niche",
+    "high": "Mainstream"
+  },
+  {
+    "id": "biggest-to-smallest",
+    "label": "Biggest to Smallest",
+    "low": "Tiny",
+    "high": "Massive"
+  },
+  {
+    "id": "hardest-to-easiest",
+    "label": "Hardest to Easiest",
+    "low": "Easy",
+    "high": "Brutal"
+  },
+  {
+    "id": "healthiest",
+    "label": "Healthiest to Least Healthy",
+    "low": "Junk",
+    "high": "Superfood"
+  },
+  {
+    "id": "cutest",
+    "label": "Cutest to Least Cute",
+    "low": "Ugly",
+    "high": "Adorable"
+  },
+  {
+    "id": "most-exciting",
+    "label": "Most Exciting to Boring",
+    "low": "Boring",
+    "high": "Thrilling"
+  },
+  {
+    "id": "strongest-to-weakest",
+    "label": "Strongest to Weakest",
+    "low": "Weak",
+    "high": "Unstoppable"
+  },
+  {
+    "id": "most-addictive",
+    "label": "Most Addictive to Least",
+    "low": "Take it or leave it",
+    "high": "Can't stop"
+  },
+  {
+    "id": "most-boring",
+    "label": "Most Boring to Most Fun",
+    "low": "Fun",
+    "high": "Snoozefest"
+  },
+  {
+    "id": "most-useful",
+    "label": "Most Useful to Least",
+    "low": "Useless",
+    "high": "Essential"
+  },
+  {
+    "id": "most-expensive",
+    "label": "Most Expensive to Cheapest",
+    "low": "Bargain",
+    "high": "Luxury"
+  },
+  {
+    "id": "most-reliable",
+    "label": "Most Reliable to Least",
+    "low": "Unreliable",
+    "high": "Rock solid"
+  },
+  {
+    "id": "most-indulgent",
+    "label": "Most Indulgent to Lightest",
+    "low": "Light",
+    "high": "Decadent"
+  },
+  {
+    "id": "most-overrated",
+    "label": "Most Overrated to Underrated",
+    "low": "Hidden gem",
+    "high": "Overhyped"
+  },
+  {
+    "id": "most-controversial",
+    "label": "Most Controversial to Tame",
+    "low": "Tame",
+    "high": "Polarizing"
+  },
+  {
+    "id": "most-talented",
+    "label": "Most Talented to Least",
+    "low": "Amateur",
+    "high": "Genius"
+  },
+  {
+    "id": "most-bingeable",
+    "label": "Most Bingeable to Least",
+    "low": "One episode is enough",
+    "high": "Can't stop watching"
+  },
+  {
+    "id": "best-to-visit",
+    "label": "Best to Visit to Skip",
+    "low": "Skip it",
+    "high": "Bucket list"
+  }
+]


### PR DESCRIPTION
## Summary
- 18 categories with emoji icons and valid scale pairings (basketball players, fast food, movies, etc.)
- 21 scale types with low/high labels (best-to-worst, scariest, most-famous, etc.)
- Typed index.ts with `Category`, `Scale` interfaces and helper functions

## Test plan
- [x] `npm run build` passes
- [x] All category scale references resolve to valid scales
- [x] 18 categories (exceeds 15+ requirement), 21 scales (exceeds 8+ requirement)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)