### PR TITLE
fix: production readiness audit

### DIFF
--- a/.doc-check-passed
+++ b/.doc-check-passed
@@ -1,7 +1,8 @@
-next.config.ts
-package-lock.json
-package.json
-src/app/api/generate-words/route.ts
-src/app/error.tsx
-src/components/game/PlayerSetup.tsx
-src/lib/supabase.ts
+src/app/imposter/play/page.tsx
+src/app/layout.tsx
+src/app/not-found.tsx
+src/app/spin-and-guess/page.tsx
+src/app/spin-and-guess/play/page.tsx
+src/components/game/ArchSpinner.tsx
+src/hooks/useMediaQuery.ts
+src/hooks/useTimer.ts

--- a/src/app/imposter/play/page.tsx
+++ b/src/app/imposter/play/page.tsx
@@ -114,8 +114,6 @@ export default function ImposterPlay() {
       <VotingPhase
         players={players}
         currentPlayerIndex={currentPlayerIndex}
-        imposterIndices={imposterIndices}
-        votes={imposterState.votes}
         onVote={(voterId, votedForId) => {
           const newVotes = { ...imposterState.votes, [voterId]: votedForId };
           const nextIndex = currentPlayerIndex + 1;
@@ -191,9 +189,6 @@ export default function ImposterPlay() {
         votes={imposterState.votes}
         secretWord={secretWord}
         category={category}
-        difficulty={imposterState.difficulty}
-        imposterCount={imposterState.imposterCount}
-        timerDuration={imposterState.timerDuration}
         isChaosRound={imposterState.isChaosRound}
         onPlayAgain={() => {
           const categoryData = categories.find((c) => c.category === category);
@@ -492,14 +487,10 @@ function DiscussionPhase({
 function VotingPhase({
   players,
   currentPlayerIndex,
-  imposterIndices,
-  votes,
   onVote,
 }: {
   players: { id: number; name: string; score: number }[];
   currentPlayerIndex: number;
-  imposterIndices: number[];
-  votes: Record<number, number>;
   onVote: (voterId: number, votedForId: number) => void;
 }) {
   const [subPhase, setSubPhase] = useState<"pass" | "vote">("pass");
@@ -707,9 +698,6 @@ function ResultsPhase({
   votes,
   secretWord,
   category,
-  difficulty,
-  imposterCount,
-  timerDuration,
   isChaosRound,
   onPlayAgain,
   onNewGame,
@@ -720,9 +708,6 @@ function ResultsPhase({
   votes: Record<number, number>;
   secretWord: string;
   category: string;
-  difficulty: string;
-  imposterCount: number;
-  timerDuration: number | null;
   isChaosRound: boolean;
   onPlayAgain: () => void;
   onNewGame: () => void;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,7 @@ export const metadata: Metadata = {
       "The ultimate pass-and-play party game. No Wi-Fi, no second devices, no accounts.",
     type: "website",
     siteName: "Sussy",
+    images: [{ url: "/icons/icon-512.png", width: 512, height: 512, alt: "Sussy" }],
   },
 };
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-dvh flex flex-col items-center justify-center px-6 text-center">
+      <h1 className="text-2xl font-bold text-text-primary mb-2">
+        Page not found
+      </h1>
+      <p className="text-text-secondary mb-6">
+        The page you&apos;re looking for doesn&apos;t exist.
+      </p>
+      <Link
+        href="/"
+        className="px-6 py-3 bg-surface border border-border rounded-xl text-text-primary font-medium hover:bg-surface-hover"
+      >
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/src/app/spin-and-guess/page.tsx
+++ b/src/app/spin-and-guess/page.tsx
@@ -91,9 +91,6 @@ export default function SpinAndGuessSetup() {
     router.push("/spin-and-guess/play");
   };
 
-  // Need at least names entered
-  const hasNames = Array.from({ length: playerCount }, (_, i) => names[i]?.trim()).some(Boolean);
-
   return (
     <GameShell title="Wavelength" accentColor={ACCENT}>
       <motion.div

--- a/src/app/spin-and-guess/play/page.tsx
+++ b/src/app/spin-and-guess/play/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import { GameShell } from "@/components/layout/GameShell";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
@@ -10,15 +10,12 @@ import { PassScreen } from "@/components/game/PassScreen";
 import { ArchSpinner } from "@/components/game/ArchSpinner";
 import { ResultsScreen } from "@/components/game/ResultsScreen";
 import { useGameStore, SpinAndGuessAssignment, SpinAndGuessRound } from "@/lib/store";
-import { vibrateSuccess } from "@/lib/haptics";
 import { fireConfetti, fireWinConfetti } from "@/lib/confetti";
 import { useWakeLock } from "@/hooks/useWakeLock";
 import {
   categories as allCategories,
   scales as allScales,
   getScale,
-  type Category,
-  type Scale,
 } from "@/data/spin-and-guess";
 import { shuffle } from "@/lib/utils";
 import { cn } from "@/lib/utils";
@@ -108,12 +105,10 @@ export default function SpinAndGuessPlay() {
       <CluesPhase
         players={players}
         nonGuessers={nonGuessers}
-        guesserIndex={state.guesserIndex}
         assignments={state.assignments}
         customCategory={state.customCategory}
         secretNumber={state.secretNumber!}
         currentClueIndex={state.currentClueIndex}
-        clues={state.clues}
         onClue={(playerIndex, clue) => {
           const newClues = { ...state.clues, [playerIndex]: clue };
           const nextClueIdx = state.currentClueIndex + 1;
@@ -149,7 +144,6 @@ export default function SpinAndGuessPlay() {
       <GuessingPhase
         guesserName={players[state.guesserIndex]?.name || "Guesser"}
         players={players}
-        guesserIndex={state.guesserIndex}
         assignments={state.assignments}
         customCategory={state.customCategory}
         clues={state.clues}
@@ -475,22 +469,18 @@ function SpinningPhase({
 function CluesPhase({
   players,
   nonGuessers,
-  guesserIndex,
   assignments,
   customCategory,
   secretNumber,
   currentClueIndex,
-  clues,
   onClue,
 }: {
   players: { id: number; name: string }[];
   nonGuessers: { id: number; name: string }[];
-  guesserIndex: number;
   assignments: SpinAndGuessAssignment[];
   customCategory: { label: string; scaleId: string; playerIndex: number } | null;
   secretNumber: number;
   currentClueIndex: number;
-  clues: Record<number, string>;
   onClue: (playerIndex: number, clue: string) => void;
 }) {
   const [subPhase, setSubPhase] = useState<"pass" | "clue">("pass");
@@ -732,7 +722,6 @@ function VerbalGuessPhase({
 function GuessingPhase({
   guesserName,
   players,
-  guesserIndex,
   assignments,
   customCategory,
   clues,
@@ -740,7 +729,6 @@ function GuessingPhase({
 }: {
   guesserName: string;
   players: { id: number; name: string }[];
-  guesserIndex: number;
   assignments: SpinAndGuessAssignment[];
   customCategory: { label: string; scaleId: string; playerIndex: number } | null;
   clues: Record<number, string>;
@@ -1025,9 +1013,6 @@ function EndScreen({
           ) / totalRounds
         ).toFixed(1)
       : "0";
-
-  // Best guesser: player with highest score
-  const bestGuesser = winner;
 
   // Worst guess: round with biggest diff
   const worstRound = roundHistory.reduce(

--- a/src/components/game/ArchSpinner.tsx
+++ b/src/components/game/ArchSpinner.tsx
@@ -74,7 +74,7 @@ export function ArchSpinner({
   const [pointerAngle, setPointerAngle] = useState(ARCH_MID); // top center
   const [result, setResult] = useState<number | null>(null);
   const onResultRef = useRef(onResult);
-  onResultRef.current = onResult;
+  useEffect(() => { onResultRef.current = onResult; }, [onResult]);
   const animRef = useRef<number>(0);
   const pointerAngleRef = useRef(ARCH_MID);
 

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -3,11 +3,13 @@
 import { useState, useEffect } from "react";
 
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(false);
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  });
 
   useEffect(() => {
     const mql = window.matchMedia(query);
-    setMatches(mql.matches);
 
     const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
     mql.addEventListener("change", handler);

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -12,7 +12,7 @@ export function useTimer({ duration, onComplete, autoStart = false }: UseTimerOp
   const [timeLeft, setTimeLeft] = useState(duration);
   const [isRunning, setIsRunning] = useState(autoStart);
   const onCompleteRef = useRef(onComplete);
-  onCompleteRef.current = onComplete;
+  useEffect(() => { onCompleteRef.current = onComplete; }, [onComplete]);
 
   const start = useCallback(() => setIsRunning(true), []);
   const pause = useCallback(() => setIsRunning(false), []);


### PR DESCRIPTION
## Summary
- Fix 3 lint errors: ref-during-render in `ArchSpinner` and `useTimer`, cascading `setState` in `useMediaQuery` (lazy initializer)
- Clean up all 14 unused variable warnings across imposter and spin-and-guess pages
- Add custom 404 page (`not-found.tsx`) matching the existing `error.tsx` pattern
- Add `og:image` metadata in root layout pointing to `/icons/icon-512.png`

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run build` — no type errors, `/_not-found` route registered
- [ ] Navigate to `/nonexistent-route` — custom 404 renders
- [ ] Verify all 3 games still play correctly (imposter, odd-one-out, spin-and-guess)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)