### PR TITLE
feat(imposter): show starting player after role reveal

### DIFF
--- a/.doc-check-passed
+++ b/.doc-check-passed
@@ -1,2 +1,3 @@
-src/app/odd-one-out/play/page.tsx
+src/app/imposter/play/page.tsx
+src/lib/gameEngine.ts
 src/lib/store.ts

--- a/src/app/imposter/play/page.tsx
+++ b/src/app/imposter/play/page.tsx
@@ -16,7 +16,7 @@ import { ResultsScreen } from "@/components/game/ResultsScreen";
 import { vibratePattern, vibrateSuccess, vibrateDanger } from "@/lib/haptics";
 import { fireConfetti, fireWinConfetti } from "@/lib/confetti";
 import { AnimatedNumber } from "@/components/game/AnimatedNumber";
-import { tallyVotes, checkImposterWin } from "@/lib/gameEngine";
+import { tallyVotes, checkImposterWin, pickStartingPlayer } from "@/lib/gameEngine";
 import { categories } from "@/data/imposter";
 import { assignImposterRoles, pickWord, rollChaosRound } from "@/lib/gameEngine";
 
@@ -72,19 +72,40 @@ export default function ImposterPlay() {
         showHintToImposter={showHintToImposter}
         onAdvance={(nextIndex) => {
           if (nextIndex >= players.length) {
-            // All players have seen their roles — move to next phase
-            const nextPhase = imposterState.enableTimer
-              ? "discussion"
-              : imposterState.enableVoting
-                ? "voting"
-                : "reveal";
+            // All players have seen their roles — pick starting player
+            const starter = pickStartingPlayer(
+              players.length,
+              imposterState.imposterIndices
+            );
             updateImposterState({
-              phase: nextPhase,
+              phase: "starting",
+              startingPlayerIndex: starter,
               currentPlayerIndex: 0,
             });
           } else {
             updateImposterState({ currentPlayerIndex: nextIndex });
           }
+        }}
+      />
+    );
+  }
+
+  // Starting player phase
+  if (phase === "starting") {
+    return (
+      <StartingPlayerPhase
+        playerName={
+          imposterState.startingPlayerIndex !== null
+            ? players[imposterState.startingPlayerIndex]?.name ?? "?"
+            : "?"
+        }
+        onContinue={() => {
+          const nextPhase = imposterState.enableTimer
+            ? "discussion"
+            : imposterState.enableVoting
+              ? "voting"
+              : "reveal";
+          updateImposterState({ phase: nextPhase, currentPlayerIndex: 0 });
         }}
       />
     );
@@ -344,6 +365,62 @@ function AssigningPhase({
 function useSubPhase() {
   const [subPhase, setSubPhase] = useState<PlayPhase>("pass");
   return { subPhase, setSubPhase };
+}
+
+function StartingPlayerPhase({
+  playerName,
+  onContinue,
+}: {
+  playerName: string;
+  onContinue: () => void;
+}) {
+  return (
+    <GameShell title="Imposter" accentColor={ACCENT}>
+      <div className="flex flex-col items-center justify-center text-center gap-6 min-h-[60dvh]">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+        >
+          <p className="text-text-muted text-sm mb-2">First to give a word...</p>
+        </motion.div>
+
+        <motion.div
+          initial={{ scale: 0.3, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ type: "spring", duration: 0.6, delay: 0.2 }}
+        >
+          <p className="text-5xl font-black" style={{ color: ACCENT }}>
+            {playerName}
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.5 }}
+          className="text-6xl"
+        >
+          👆
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.7 }}
+          className="w-full max-w-sm"
+        >
+          <Button
+            accentColor={ACCENT}
+            fullWidth
+            size="lg"
+            onClick={onContinue}
+          >
+            Continue
+          </Button>
+        </motion.div>
+      </div>
+    </GameShell>
+  );
 }
 
 function DiscussionPhase({

--- a/src/lib/gameEngine.ts
+++ b/src/lib/gameEngine.ts
@@ -71,6 +71,23 @@ export function pickOddOneOut(playerCount: number): number {
   return Math.floor(Math.random() * playerCount);
 }
 
+export function pickStartingPlayer(
+  playerCount: number,
+  imposterIndices: number[]
+): number {
+  // Weight non-imposters 4x more likely than imposters
+  const weights = Array.from({ length: playerCount }, (_, i) =>
+    imposterIndices.includes(i) ? 1 : 4
+  );
+  const totalWeight = weights.reduce((sum, w) => sum + w, 0);
+  let roll = Math.random() * totalWeight;
+  for (let i = 0; i < playerCount; i++) {
+    roll -= weights[i];
+    if (roll <= 0) return i;
+  }
+  return 0;
+}
+
 export function checkImposterWin(
   votedOutId: number,
   imposterIndices: number[],

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -15,7 +15,7 @@ export interface ImposterState {
   secretHint: string;
   imposterIndices: number[];
   currentPlayerIndex: number;
-  phase: "setup" | "assigning" | "discussion" | "voting" | "reveal" | "results";
+  phase: "setup" | "assigning" | "starting" | "discussion" | "voting" | "reveal" | "results";
   votes: Record<number, number>;
   timerDuration: number | null;
   difficulty: "easy" | "medium" | "hard" | "mixed";
@@ -25,6 +25,7 @@ export interface ImposterState {
   showCategoryToImposter: boolean;
   showHintToImposter: boolean;
   isChaosRound: boolean;
+  startingPlayerIndex: number | null;
 }
 
 export interface OddOneOutState {
@@ -126,6 +127,7 @@ const defaultImposterState: ImposterState = {
   showCategoryToImposter: true,
   showHintToImposter: false,
   isChaosRound: false,
+  startingPlayerIndex: null,
 };
 
 const defaultOddOneOutState: OddOneOutState = {


### PR DESCRIPTION
## Summary
- Adds a "starting player" screen between role assignment and discussion/voting/reveal
- Starting player is chosen with weighted randomness — non-imposters are 4x more likely to be picked
- New `pickStartingPlayer()` utility in gameEngine with weighted selection
- New `"starting"` phase and `startingPlayerIndex` in store

## Test plan
- [ ] Start Imposter game, complete role reveals, verify starting player screen appears
- [ ] Confirm the starting player name is displayed with animation
- [ ] Verify "Continue" button transitions to correct next phase (discussion/voting/reveal depending on settings)
- [ ] Play multiple games and verify imposters are picked less often as starter
- [ ] Test "Play Again" flow still works correctly

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)