### PR TITLE
fix(imposter): improve AI hints, fix custom play-again & hydration

### DIFF
--- a/.doc-check-passed
+++ b/.doc-check-passed
@@ -1,3 +1,5 @@
+src/app/api/generate-words/route.ts
+src/app/imposter/page.tsx
 src/app/imposter/play/page.tsx
-src/lib/gameEngine.ts
+src/hooks/useMediaQuery.ts
 src/lib/store.ts

--- a/src/app/api/generate-words/route.ts
+++ b/src/app/api/generate-words/route.ts
@@ -53,7 +53,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const completion = await openai.chat.completions.create({
-      model: "gpt-4o-mini",
+      model: "gpt-4o",
       temperature: 0.8,
       max_tokens: 1024,
       messages: [
@@ -66,7 +66,19 @@ Given a topic, produce exactly 15 words related to that topic:
 - 5 medium (moderately known)
 - 5 hard (obscure or niche)
 
-Each word must have a short hint (a vague clue that helps the imposter blend in without giving the word away).
+Each word must have a short hint — a loose ASSOCIATION, not a definition or description. The hint should evoke a related concept, setting, or vibe so the imposter can bluff in the right direction without knowing the actual word.
+
+GOOD hints (associations):
+- Word "Guitar" → hint "campfire"
+- Word "Sushi" → hint "Tokyo"
+- Word "Telescope" → hint "stargazing"
+
+BAD hints (too descriptive — NEVER do this):
+- Word "Guitar" → hint "stringed instrument"
+- Word "Sushi" → hint "raw fish and rice"
+- Word "Telescope" → hint "magnifies distant objects"
+
+Hints must be 1-2 words max. Never use synonyms, definitions, or "used for..." descriptions.
 
 Respond with ONLY valid JSON, no markdown fences. Use this exact shape:
 {

--- a/src/app/imposter/page.tsx
+++ b/src/app/imposter/page.tsx
@@ -179,6 +179,7 @@ export default function ImposterSetup() {
       showCategoryToImposter,
       showHintToImposter,
       isChaosRound,
+      customCategoryData: isCustom ? categoryData : null,
       currentPlayerIndex: 0,
       phase: "assigning",
       votes: {},

--- a/src/app/imposter/play/page.tsx
+++ b/src/app/imposter/play/page.tsx
@@ -168,7 +168,7 @@ export default function ImposterPlay() {
         playerCount={players.length}
         isChaosRound={imposterState.isChaosRound}
         onPlayAgain={() => {
-          const categoryData = categories.find((c) => c.category === category);
+          const categoryData = categories.find((c) => c.category === category) ?? imposterState.customCategoryData;
           if (!categoryData) return;
           const { word: newWord, hint: newHint } = pickWord(categoryData, imposterState.difficulty);
           let newIndices = assignImposterRoles(
@@ -212,7 +212,7 @@ export default function ImposterPlay() {
         category={category}
         isChaosRound={imposterState.isChaosRound}
         onPlayAgain={() => {
-          const categoryData = categories.find((c) => c.category === category);
+          const categoryData = categories.find((c) => c.category === category) ?? imposterState.customCategoryData;
           if (!categoryData) return;
           const { word: newWord, hint: newHint } = pickWord(categoryData, imposterState.difficulty);
           let newIndices = assignImposterRoles(

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -3,13 +3,11 @@
 import { useState, useEffect } from "react";
 
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.matchMedia(query).matches;
-  });
+  const [matches, setMatches] = useState(false);
 
   useEffect(() => {
     const mql = window.matchMedia(query);
+    setMatches(mql.matches);
 
     const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
     mql.addEventListener("change", handler);

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { CategoryData } from "@/lib/gameEngine";
 
 export interface Player {
   id: number;
@@ -26,6 +27,7 @@ export interface ImposterState {
   showHintToImposter: boolean;
   isChaosRound: boolean;
   startingPlayerIndex: number | null;
+  customCategoryData: CategoryData | null;
 }
 
 export interface OddOneOutState {
@@ -128,6 +130,7 @@ const defaultImposterState: ImposterState = {
   showHintToImposter: false,
   isChaosRound: false,
   startingPlayerIndex: null,
+  customCategoryData: null,
 };
 
 const defaultOddOneOutState: OddOneOutState = {


### PR DESCRIPTION
## Summary
- Rework AI prompt for custom categories to produce **association-style hints** (e.g. "campfire" for Guitar) instead of definitions (e.g. "stringed instrument"). Includes explicit good/bad examples in prompt.
- Upgrade model from `gpt-4o-mini` to `gpt-4o` for better instruction following
- Fix **play-again button not working** for custom AI categories by storing `customCategoryData` in imposter state
- Fix **hydration mismatch** on landing page by initializing `useMediaQuery` to `false`

## Test plan
- [ ] Generate a custom category and verify hints are associations, not definitions
- [ ] Play a full game with a custom category, hit "Play Again" — should work
- [ ] Load the landing page on desktop — no hydration error in console
- [ ] Standard (non-custom) categories still work for play-again

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)